### PR TITLE
feat: add autoApprove support to autonomy config

### DIFF
--- a/chart/zeroclaw/Chart.yaml
+++ b/chart/zeroclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zeroclaw
 description: Helm chart for deploying ZeroClaw on Kubernetes
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: v0.1.7
 home: https://github.com/niklasfrick/zeroclaw-helm
 icon: https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/zeroclaw.png

--- a/chart/zeroclaw/Chart.yaml
+++ b/chart/zeroclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zeroclaw
 description: Helm chart for deploying ZeroClaw on Kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: v0.1.7
 home: https://github.com/niklasfrick/zeroclaw-helm
 icon: https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/zeroclaw.png

--- a/chart/zeroclaw/templates/configmap.yaml
+++ b/chart/zeroclaw/templates/configmap.yaml
@@ -57,6 +57,9 @@ data:
     max_cost_per_day_cents = {{ .Values.config.autonomy.maxCostPerDayCents }}
     require_approval_for_medium_risk = {{ .Values.config.autonomy.requireApprovalForMediumRisk }}
     block_high_risk_commands = {{ .Values.config.autonomy.blockHighRiskCommands }}
+    {{- if .Values.config.autonomy.autoApprove }}
+    auto_approve = {{ include "zeroclaw.tomlStringList" .Values.config.autonomy.autoApprove }}
+    {{- end }}
 
     # ── Runtime ───────────────────────────────────────────────
     [runtime]

--- a/chart/zeroclaw/values.schema.json
+++ b/chart/zeroclaw/values.schema.json
@@ -646,6 +646,14 @@
               "type": "boolean",
               "default": true,
               "description": "Block high-risk commands entirely."
+            },
+            "autoApprove": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [],
+              "description": "Tool operations that are automatically approved without user confirmation."
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary

Adds `autoApprove` as a first-class Helm value under `config.autonomy`, allowing users to specify which tool operations should be automatically approved in daemon/channel mode.

## Problem

The zeroclaw binary supports `auto_approve` in its TOML config (used in `[autonomy]`), but the Helm chart did not expose this field. Users running in `daemon` mode with Discord/Telegram had to either:
- Use the `extraConfig` workaround to inject raw TOML (which can conflict with duplicate section headers)
- Accept approval prompts on every tool call

## Changes

**`values.schema.json`** — added `autoApprove` array property under `config.autonomy.properties`:
```json
"autoApprove": {
  "type": "array",
  "items": { "type": "string" },
  "default": [],
  "description": "Tool operations that are automatically approved without user confirmation."
}
```

**`templates/configmap.yaml`** — added one conditional block under `[autonomy]`:
```go-template
{{- if .Values.config.autonomy.autoApprove }}
auto_approve = {{ include "zeroclaw.tomlStringList" .Values.config.autonomy.autoApprove }}
{{- end }}
```

## Usage

```yaml
config:
  autonomy:
    autoApprove:
      - file_read
      - file_write
      - web_fetch
      - web_search
```

## Follows existing patterns

- Uses the existing `zeroclaw.tomlStringList` helper (same as `allowedCommands`, `forbiddenPaths`)
- Follows the exact same conditional style as other optional autonomy fields
- No new helpers or structural changes